### PR TITLE
Add blockchain as a posts tag

### DIFF
--- a/source/posts/2016-12-01-blockchains-a-brief-introduction.html.markdown
+++ b/source/posts/2016-12-01-blockchains-a-brief-introduction.html.markdown
@@ -2,7 +2,7 @@
 title: "Blockchains: A brief introduction"
 author: michald
 cover_photo: cover.png
-tags: development, entrepreneurship
+tags: development, entrepreneurship, blockchain
 ---
 
 This post begins a series about the blockchain technology wherein I will try to answer the common questions like what it is, how it works and where blockchains are used. However, I will not go into technical details, I will only focus on a general overview.

--- a/source/posts/2017-04-06-code-your-own-bitcoin-transaction.html.markdown
+++ b/source/posts/2017-04-06-code-your-own-bitcoin-transaction.html.markdown
@@ -2,7 +2,7 @@
 title: Code your own bitcoin transaction
 author: piotr
 cover_photo: cover.png
-tags: development
+tags: development, blockchain
 ---
 
 Today we will code our first bitcoin transaction. To achieve this goal we will use JavaScript library called [bitcore](https://github.com/bitpay/bitcore-lib). JavaScript is the most popular, modern programming language and almost every developer knows it, so it makes this article universal and useful for the wider audience.

--- a/source/posts/2017-06-06-bitcoin-multi-sig-transaction-part-1.html.markdown
+++ b/source/posts/2017-06-06-bitcoin-multi-sig-transaction-part-1.html.markdown
@@ -2,7 +2,7 @@
 title: Bitcoin multi-sig transaction part 1
 author: piotr
 cover_photo: cover.png
-tags: development
+tags: development, blockchain
 ---
 Welcome again. In this episode, we will code a bitcoin multi-sig transaction based on the bitcore library.
 

--- a/source/posts/2017-07-22-bitcoin-multi-sig-transaction-part-2.html.markdown
+++ b/source/posts/2017-07-22-bitcoin-multi-sig-transaction-part-2.html.markdown
@@ -2,7 +2,7 @@
 title: Bitcoin multi-sig transaction part 2
 author: piotr
 cover_photo: cover.png
-tags: development
+tags: development, blockchain
 ---
 Welcome back bitcoin freaks. [In the previous episode](https://blog.ragnarson.com/2017/06/06/bitcoin-multi-sig-transaction-part-1.html), we created a multi-sig transaction. [Go back to that blog post](https://blog.ragnarson.com/2017/06/06/bitcoin-multi-sig-transaction-part-1.html) if you don't know what `multi-sig` means.
 


### PR DESCRIPTION
The separated category for blockchain related content is needed to
show outside our expertise in this field. With one link we will
be able to show that we are in the field for over one year.

It will be used in our profile on moneo.io - blockchain experts
and clients matching platform. We can also use it on our
blockchain related landing pages